### PR TITLE
refactor game->sim and stub out remaining simulator classes

### DIFF
--- a/simulator/basicrobot.cpp
+++ b/simulator/basicrobot.cpp
@@ -1,4 +1,5 @@
 #include "basicrobot.h"
+#include "drawable_robot.h"
 
 BasicRobot::BasicRobot(double x, double y, double angle) {
 	x_pos = x;

--- a/simulator/basicrobot.h
+++ b/simulator/basicrobot.h
@@ -1,6 +1,7 @@
 #ifndef basicrobot_h
 #define basicrobot_h
 #include "robot.h"
+#include "drawable_robot.h"
 
 class BasicRobot: public Robot { //basic robot for testing purposes
 	public: BasicRobot(double x, double y, double angle);

--- a/simulator/drawable_robot.h
+++ b/simulator/drawable_robot.h
@@ -1,0 +1,8 @@
+#ifndef drawable_robot_h
+#define drawable_robot_h
+
+// stub class to set up the filestructure of simulator/
+// holds defines methoda and data about a robot that we use to draw it using SFML
+class DrawableRobot {};
+
+#endif

--- a/simulator/hardware_interaction.h
+++ b/simulator/hardware_interaction.h
@@ -1,0 +1,4 @@
+#ifndef hardware_interaction_h
+#define hardware_interaction_h
+
+#endif

--- a/simulator/robot_action_interface.h
+++ b/simulator/robot_action_interface.h
@@ -1,0 +1,6 @@
+#ifndef robot_action_interface
+#define robot_action_interface
+
+class RobotAction{};
+
+#endif

--- a/simulator/sensor_interface.h
+++ b/simulator/sensor_interface.h
@@ -1,0 +1,6 @@
+#ifndef sensor_interface_h
+#define sensor_interface_h
+
+class Sensor{};
+
+#endif

--- a/simulator/sim.cpp
+++ b/simulator/sim.cpp
@@ -1,4 +1,4 @@
-#include "game.h"
+#include "sim.h"
 
 
 

--- a/simulator/sim.h
+++ b/simulator/sim.h
@@ -1,5 +1,5 @@
-#ifndef game_h
-#define game_h
+#ifndef sim_h
+#define sim_h
 
 #include "robot.h"
 #include "basicrobot.h"

--- a/simulator/strategy.h
+++ b/simulator/strategy.h
@@ -1,0 +1,14 @@
+#ifndef strategy_h
+#define strategy_h
+#include <vector> 
+
+// stub class for strategy
+// every new strategy we create must include strategy_h so since we call upon standardized methods 
+// in sim to execute these strategies.
+class Strategy {
+    public: 
+        // returns vector of size 2 containing ints [0, 100] to indicate left and right motor output % respectively 
+        virtual std::vector<int> next_action() = 0;
+};
+
+#endif


### PR DESCRIPTION
Changes: 
- refactored game.cpp -> sim.cpp and game.h -> sim.h
- added stub classes: 
  - drawable_robot
  - hardware_interaction
  - robot_action_interface
  - sensor_interface
  - strategy

To compile and test (macOS):
1. compile: `robowrestling-software/simulator$ g++ -c *.cpp`
2. link: `robowrestling-software/simulator$ g++ sim.o -o sfml-app -lsfml-graphics -lsfml-window -lsfml-system basicrobot.o`
3. run the app: `robowrestling-software/simulator$ ./sfml-app`
